### PR TITLE
Add support for Davis AirLink Air Quality Monitor (type 6 in the API)

### DIFF
--- a/custom_components/davis_weatherlink_live/api_sample.md
+++ b/custom_components/davis_weatherlink_live/api_sample.md
@@ -9,6 +9,8 @@ The data_structure_type field can be used to determine what type of record a JSO
 
 4 = LSS Temp/Hum Current Conditions record
 
+6 = Air Quality Monitor
+
 {
     "data":
     {
@@ -90,7 +92,35 @@ The data_structure_type field can be used to determine what type of record a JSO
                 "bar_sea_level":30.008,                        // most recent bar sensor reading with elevation adjustment **(inches)**
                 "bar_trend":null,                              // current 3 hour bar trend **(inches)**
                 "bar_absolute":30.008                          // raw bar sensor reading **(inches)**
-            }
+            },
+            {
+                "lsid": 852455,
+                "data_structure_type": 6,
+                "temp": 70.9,                                   // most recent valid inside temp **(°F)**
+                "hum": 58.1,                                    // most recent valid inside humidity **(%RH)**
+                "dew_point": 55.4,                              // **(°F)**
+                "wet_bulb": 59.9,                               // **(°F)**
+                "heat_index": 70.3,                             // **(°F)**
+                "pm_1_last": 2,
+                "pm_2p5_last": 2,
+                "pm_10_last": 2,
+                "pm_1": 2.71,                                   // current PM 1 measurement **µg/m³" (micrograms per cubic meter)**
+                "pm_2p5": 3.31,                                 // current PM 2.5 measurement **µg/m³" (micrograms per cubic meter)**
+                "pm_2p5_last_1_hour": 3.84,
+                "pm_2p5_last_3_hours": 4.08,
+                "pm_2p5_last_24_hours": 2.61,
+                "pm_2p5_nowcast": 4.0,
+                "pm_10": 3.89,                                  // current PM 10 measurement **µg/m³" (micrograms per cubic meter)**
+                "pm_10_last_1_hour": 4.45,
+                "pm_10_last_3_hours": 4.66,
+                "pm_10_last_24_hours": 3.09,
+                "pm_10_nowcast": 4.61,
+                "last_report_time": 1751909719,
+                "pct_pm_data_last_1_hour": 100,
+                "pct_pm_data_last_3_hours": 100,
+                "pct_pm_data_nowcast": 100,
+                "pct_pm_data_last_24_hours": 100
+        }
         ]
     },
     "error":null

--- a/custom_components/davis_weatherlink_live/davis_weatherlink_live.py
+++ b/custom_components/davis_weatherlink_live/davis_weatherlink_live.py
@@ -289,6 +289,22 @@ class DavisWeatherLinkLive:
                         "heat_index_in" + unique_key: condition.get("heat_index_in"),
                     }
                 )
+                
+            elif data_type == 6:  # Air Quality Monitor
+                unique_id = condition.get("lsid")
+                unique_key = f"_ls{unique_id}"
+                weather_data.update(
+                    {
+                        "lsid" + unique_key: condition.get("lsid"),
+                        "temp" + unique_key: condition.get("temp"),
+                        "hum" + unique_key: condition.get("hum"),
+                        "dew_point" + unique_key: condition.get("dew_point"),
+                        "heat_index" + unique_key: condition.get("heat_index"),
+                        "pm_1" + unique_key: condition.get("pm_1"),
+                        "pm_2p5" + unique_key: condition.get("pm_2p5"),
+                        "pm_10" + unique_key: condition.get("pm_10"),
+                    }
+                )
 
             elif data_type == 3:  # LSS BAR Current Conditions record
                 unique_id = condition.get("lsid")

--- a/custom_components/davis_weatherlink_live/manifest.json
+++ b/custom_components/davis_weatherlink_live/manifest.json
@@ -9,6 +9,6 @@
     "issue_tracker": "https://github.com/stevesinchak/ha-weatherlink-live/issues",
     "requirements": [],
     "single_config_entry": true,
-    "version": "25.5.1",
+    "version": "25.5.2",
     "zeroconf": [ "_weatherlinklive._tcp.local." ]
   }

--- a/custom_components/davis_weatherlink_live/sensor.py
+++ b/custom_components/davis_weatherlink_live/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     DEGREE,
     PERCENTAGE,
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     UnitOfLength,
     UnitOfPressure,
     UnitOfSpeed,
@@ -42,6 +43,8 @@ def get_device_name(condition: tuple):
             return "Davis LSS BAR"  # + str(condition.get("lsid"))
         case 4:
             return "Davis LSS"  # + str(condition.get("lsid"))
+        case 6:
+            return "Davis AirLink AQM"  # + str(condition.get("lsid"))
 
 
 # Device Sensor type helper that returns the correct sensors based on the device type
@@ -625,6 +628,77 @@ def get_device_sensors(condition: tuple):
             ),
         )
         return DST_4
+
+    elif device_type == 6:  # WeatherLink Air Quality Monitors
+        unique_id = condition.get("lsid")
+        unique_key = f"_ls{unique_id}"
+        # Device Sensor Type 6: Weatherlink AQI Conditions
+        DST_6: tuple[SensorEntityDescription, ...] = (
+            SensorEntityDescription(
+                key="lsid" + unique_key,
+                translation_key="lsid",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                entity_registry_visible_default=False,
+                entity_registry_enabled_default=False,
+            ),
+            SensorEntityDescription(
+                key="data_structure_type" + unique_key,
+                translation_key="dst",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                entity_registry_visible_default=False,
+                entity_registry_enabled_default=False,
+            ),
+            SensorEntityDescription(
+                key="temp" + unique_key,
+                translation_key="temp",
+                native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+                device_class=SensorDeviceClass.TEMPERATURE,
+                state_class=SensorStateClass.MEASUREMENT,
+            ),
+            SensorEntityDescription(
+                key="hum" + unique_key,
+                translation_key="hum",
+                native_unit_of_measurement=PERCENTAGE,
+                device_class=SensorDeviceClass.HUMIDITY,
+                state_class=SensorStateClass.MEASUREMENT,
+            ),
+            SensorEntityDescription(
+                key="dew_point" + unique_key,
+                translation_key="dew_point",
+                native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+                device_class=SensorDeviceClass.TEMPERATURE,
+            ),
+            SensorEntityDescription(
+                key="heat_index" + unique_key,
+                translation_key="heat_index",
+                native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+                device_class=SensorDeviceClass.TEMPERATURE,
+                state_class=SensorStateClass.MEASUREMENT,
+            ),
+            SensorEntityDescription(
+                key="pm_1" + unique_key,
+                translation_key="pm_1",
+                native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                device_class=SensorDeviceClass.PM1,
+                state_class=SensorStateClass.MEASUREMENT,
+            ),
+            SensorEntityDescription(
+                key="pm_2p5" + unique_key,
+                translation_key="pm_2p5",
+                native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                device_class=SensorDeviceClass.PM25,
+                state_class=SensorStateClass.MEASUREMENT,
+            ),
+            SensorEntityDescription(
+                key="pm_10" + unique_key,
+                translation_key="pm_10",
+                native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                device_class=SensorDeviceClass.PM10,
+                state_class=SensorStateClass.MEASUREMENT,
+            ),
+        )
+        return DST_6
+
 
     else:
         _LOGGER.warning("Unknown API device type %s", device_type)

--- a/custom_components/davis_weatherlink_live/strings.json
+++ b/custom_components/davis_weatherlink_live/strings.json
@@ -183,6 +183,39 @@
             },
             "wet_leaf_2": {
                 "name": "Leaf Wetness 2"
+            },
+            "pm_1_last": {
+                "name": "PM1 Last"
+            },
+            "pm_2p5_last": {
+                "name": "PM2.5 Last"
+            },
+            "pm_25p_last_1_hour": {
+                "name": "PM2.5 Last Hour"
+            },
+            "pm_25p_last_3_hours": {
+                "name": "PM2.5 Last 3 hours"
+            },
+            "pm_25p_last_24_hours": {
+                "name": "PM2.5 Last 24 Hours"
+            },
+            "pm_25p_nowcast": {
+                "name": "PM2.5 Nowcast"
+            },
+            "pm_10": {
+                "name": "PM10"
+            },
+            "pm_10_last_1_hour": {
+                "name": "PM10 Last Hour"
+            },
+            "pm_10_last_3_hours": {
+                "name": "PM10 Last 3 Hours"
+            },
+            "pm_10_last_24_hours": {
+                "name": "PM10 Last 24 Hours"
+            },
+            "pm_10_nowcast": {
+                "name": "PM10 Nowcast"
             }
         }
     },

--- a/custom_components/davis_weatherlink_live/translations/en.json
+++ b/custom_components/davis_weatherlink_live/translations/en.json
@@ -183,6 +183,15 @@
             },
             "wet_leaf_2": {
                 "name": "Leaf Wetness 2"
+            },
+            "pm1": {
+                "name": "PM1"
+            },
+            "pm2p5": {
+                "name": "PM2.5"
+            },
+            "pm10": {
+                "name": "PM10"
             }
         }
     },


### PR DESCRIPTION
This PR adds support for [Davis AirLink Air Quality Monitors](https://www.davisinstruments.com/pages/airlink). I've tested it on my own monitor, works great. I bumped the version to 25.5.2 to reflect the change.